### PR TITLE
Fixed Low Battery Notification

### DIFF
--- a/InfiniLink/Settings/SettingsFunctions.swift
+++ b/InfiniLink/Settings/SettingsFunctions.swift
@@ -21,10 +21,10 @@ class BatteryNotifications: ObservableObject {
 				twenty = false
 				ten = false
 			} else if (bat <= 20 && bat > 10) && twenty == false {
-                bleWriteManger.sendNotification(title: "Low Battery", body: "\(bat)% battery remaining")
+				bleWriteManger.sendNotification(title: NSLocalizedString("battery_low", comment: ""), body: "\(bat)% " + NSLocalizedString("battery_low_message", comment: ""))
 				twenty = true
 			} else if (bat <= 10 && bat > 5) && ten == false {
-                bleWriteManger.sendNotification(title: "Low Battery", body: "\(bat)% battery remaining")
+				bleWriteManger.sendNotification(title: NSLocalizedString("battery_low", comment: ""), body: "\(bat)% " + NSLocalizedString("battery_low_message", comment: ""))
 				ten = true
 			}
 		}

--- a/InfiniLink/Settings/SettingsFunctions.swift
+++ b/InfiniLink/Settings/SettingsFunctions.swift
@@ -16,15 +16,15 @@ class BatteryNotifications: ObservableObject {
 	
 	func notify(bat: Int, bleManager: BLEManager) {
 		let bleWriteManger = BLEWriteManager()
-		if UserDefaults.standard.object(forKey: "batteryNotifications") as! Bool? == true{
+		if UserDefaults.standard.object(forKey: "batteryNotification") as! Bool? == true{
 			if bat > 20 {
 				twenty = false
 				ten = false
 			} else if (bat <= 20 && bat > 10) && twenty == false {
-				bleWriteManger.sendNotification(title: "", body: NSLocalizedString("battery_low", comment: ""))
+                bleWriteManger.sendNotification(title: "Low Battery", body: "\(bat)% battery remaining")
 				twenty = true
 			} else if (bat <= 10 && bat > 5) && ten == false {
-				bleWriteManger.sendNotification(title: "", body: NSLocalizedString("battery_low", comment: ""))
+                bleWriteManger.sendNotification(title: "Low Battery", body: "\(bat)% battery remaining")
 				ten = true
 			}
 		}

--- a/InfiniLink/en.lproj/Localizable.strings
+++ b/InfiniLink/en.lproj/Localizable.strings
@@ -185,6 +185,7 @@
 
 // - BatteryNotifications
 "battery_low" = "Battery Low";
+"battery_low_message" = "battery remaining";
 
 // - MusicController
 "not_playing" = "Not Playing";

--- a/InfiniLink/fr.lproj/Localizable.strings
+++ b/InfiniLink/fr.lproj/Localizable.strings
@@ -185,6 +185,7 @@
 
 // - BatteryNotifications
 "battery_low" = "Battery faible";
+"battery_low_message" = "";
 
 // - MusicController
 "not_playing" = "Pas d'activité";

--- a/InfiniLink/ko.lproj/Localizable.strings
+++ b/InfiniLink/ko.lproj/Localizable.strings
@@ -185,6 +185,7 @@
 
 // - BatteryNotifications
 "battery_low" = "배터리 부족";
+"battery_low_message" = "";
 
 // - MusicController
 "not_playing" = "Not Playing";

--- a/InfiniLink/ru.lproj/Localizable.strings
+++ b/InfiniLink/ru.lproj/Localizable.strings
@@ -185,6 +185,7 @@
 
 // - BatteryNotifications
 "battery_low" = "Низкий заряд аккумулятора";
+"battery_low_message" = "";
 
 // - MusicController
 "not_playing" = "Ничего не играет";


### PR DESCRIPTION
When I was rewriting the battery chart UI, I’ve come across a mistype in the low battery notification code, so I’ve fixed that and reworded the message a bit.